### PR TITLE
Upgrading NRPE module to v1.1.1

### DIFF
--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -105,7 +105,7 @@ mod 'augeasproviders_pam',
 
 mod 'nrpe',
  :git => 'https://github.com/ghoneycutt/puppet-module-nrpe.git',
- :ref => 'v0.9.0'
+ :ref => 'v1.1.1'
 
 mod 'yum',
  :git => 'https://github.com/evenup/evenup-yum.git',


### PR DESCRIPTION
NRPE module recently got upgraded to resolve this warning:

```
==> default: Warning: Scope(Class[Nrpe]): type() DEPRECATED: This function will cease to function on Puppet 4; please use type3x() before upgrading to puppet 4 for backwards-compatibility, or migrate to the new parser's typing system.
```
