### PR TITLE
Fixing MOTD profile for Vagrant

### DIFF
--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -20,7 +20,7 @@ class profile::base {
   #
   case $::kernel {
     'Linux': {
-      if !$::vagrant { include profile::base::motd }
+      include profile::base::motd
       include profile::base::ssh
       include profile::base::dns_client
       include profile::base::access_and_sudoers

--- a/site/profile/manifests/base/motd.pp
+++ b/site/profile/manifests/base/motd.pp
@@ -2,45 +2,45 @@
 #
 #
 class profile::base::motd {
+  
+  package { 'figlet': }
 
-  if $::osfamily == 'RedHat' {
+  if $::is_pe == true {
+    $agent = 'Puppet Enterprise Agent'
+    $puppet_service = 'pe-puppet'
+    $classestxt = '/var/opt/lib/pe-puppet/classes.txt'
+  }
+  else {
+    $agent = 'Puppet Agent'
+    $puppet_service = 'puppet'
+    $classestxt = '/var/lib/puppet/state/classes.txt'
+  }
 
-    package { 'figlet': }
-    
-    $ascii = generate('/bin/sh', '-c', "/usr/bin/figlet -c -w 60 ${::domain}")
-
-    if $::is_pe == true {
-      $agent      = 'Puppet Enterprise Agent'
-      $classestxt = '/var/opt/lib/pe-puppet/classes.txt'
-    }
-    else {
-      $agent      = 'Puppet Agent'
-      $classestxt = '/var/lib/puppet/classes.txt'
-    }
-
-    if !$app_role { $app_role = 'none' }
-    if !$app_tier { $app_tier = 'none' }
-
-    file { '/etc/profile.d/motd.sh':
-      mode    => '0755',
-      content => template('profile/motd/motd.sh.erb')
-    }
-
-    file { '/etc/issue.net':
-      mode    => '0644',
-      content => template('profile/motd/issue.net.erb')
-    }
-
+  if !$::vagrant {
     file { '/tmp/classes.tmp':
       source             => $classestxt,
       source_permissions => 'ignore',
     }
-
-
   }
 
-  else {
-    notify { "${::osfamily} OS family not supported": }
+  if !$app_role { $app_role = 'none' }
+  if !$app_tier { $app_tier = 'none' }
+  
+  case $::osfamily {
+    'RedHat': {
+      file { '/etc/profile.d/motd.sh':
+        mode    => '0755',
+        content => template('profile/motd/motd.sh.erb'),
+        require => [ Package['figlet'], ],
+      }
+      file { '/etc/issue.net':
+        mode    => '0644',
+        content => template('profile/motd/issue.net.erb'),
+        notify  => [ Service['sshd'], ],
+      }
+    }
+
+    default: { notify { "${::osfamily} OS family not supported": } }
   }
 
 }

--- a/site/profile/templates/motd/motd.sh.erb
+++ b/site/profile/templates/motd/motd.sh.erb
@@ -1,37 +1,29 @@
 #!/bin/bash
 
-cat << "EOF"
-
-<%= ascii %>
-
-EOF
-
-PUPPET_PROFILES_BASE="$(grep ^profile::base /tmp/classes.tmp | awk -F \: '{print $5}' | sort | uniq)"
-PUPPET_PROFILES_APPS="$(grep ^profile::software /tmp/classes.tmp | awk -F \: '{print $5}' | sort | uniq)"
-PUPPET_PROFILES="$PUPPET_PROFILES_BASE $PUPPET_PROFILES_APPS"
-
-if [ "$(facter is_pe)" == true ]
-then
-  puppet_service="pe-puppet"
-else
-  puppet_service="puppet"
+if [ -f '/tmp/classes.tmp' ]; then
+ PUPPET_PROFILES_BASE="$(grep ^profile::base /tmp/classes.tmp | awk -F \: '{print $5}' | sort | uniq)"
+ PUPPET_PROFILES_APPS="$(grep ^profile::apps /tmp/classes.tmp | awk -F \: '{print $5}' | sort | uniq)"
+ PUPPET_PROFILES="$PUPPET_PROFILES_BASE $PUPPET_PROFILES_APPS"
 fi
 
-if [ "$(service $puppet_service status)" ]
+if [ "$(service <%= @puppet_service %> status)" ]
 then
- PUPPET_AGENT_STATUS="$(service $puppet_service status)"
+ PUPPET_AGENT_STATUS="$(service <%= @puppet_service %> status)"
 else
  PUPPET_AGENT_STATUS="[ NOT RUNNING ]"
 fi
 
-echo
-echo "  This host is running <%= agent %> with the following profiles:"
-echo "$(echo $PUPPET_PROFILES | fmt -w 60 | boxes -d stone | sed 's/^/   /')"
+figlet -c -w 60 $(facter hostname)
+
+if [ "$PUPPET_PROFILES" ]; then
+ echo "  This host is running <%= @agent %> with the following profiles:"
+ echo "$(echo $PUPPET_PROFILES | fmt -w 60 | boxes -d stone | sed 's/^/   /')"
+fi
 echo
 echo "     Puppet Agent Status: $PUPPET_AGENT_STATUS"
-echo "      Puppet Environment: <%= environment %>  "
-echo "                App Role: <%= app_role %>     "
-echo "                App Tier: <%= app_tier %>     "
+echo "      Puppet Environment: <%= @environment %>  "
+echo "                App Role: <%= @app_role %>     "
+echo "                App Tier: <%= @app_tier %>     "
 echo
 echo "  Welcome to $(hostname), $(whoami).          "
 echo


### PR DESCRIPTION
Vagrant's puppet provisioner uses `puppet apply` (rather than `puppet agent)` and does not write a `classes.txt`. Therefore, I had to do a conditional for `if !$vagrant` to enable the feature for the classes  tagcloud (_profiles_ tagcloud, technically)
