### PR TITLE
Added Puppet 4 Installer to Ubuntu Server 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
-# puppet-controlrepo
+puppet-controlrepo
+==================
 
 This project serves as a complete starter kit for your Puppet controlled infrastructure. It is feature filled with everything you ever wanted but never had; such as *Hiera*, *R10K*, *Roles and Profiles framework*, and *Vagrant*.
 
-## Project Goals
+Project Goals
+-------------
 
-  1. Whitelabel so that anyone can use this project from a class demo all the way to a full blown Fortune 500 datacenter
-  1. Compatible with as many operating systems as possible
-  1. Stay current with all the best practices
+1.	Whitelabel so that anyone can use this project from a class demo all the way to a full blown Fortune 500 datacenter
+2.	Compatible with as many operating systems as possible
+3.	Stay current with all the best practices
 
-## Installation and Usage
+Installation and Usage
+----------------------
 
-  1. Clone the repo
-  1. Install some vagrant plugins
-    1. `vagrant plugin install vagrant-cachier`
-    1. `vagrant plugin install vagrant-r10k`
-  1. `vagrant up` and watch your new virtual machine get fully provisioned
-  1. `vagrant ssh` and have a look around
-  1. Now try making a change to some YAML data. Edit [`common.yaml`](hieradata/common.yaml) and add/remove a DNS server, just for fun
-  1. `vagrant provision`, now watch the DNS client configuration recieve your change.
+1.	Clone the repo
+2.	Install some vagrant plugins
+	1.	`vagrant plugin install vagrant-cachier`
+	2.	`vagrant plugin install vagrant-r10k`
+3.	set your desired puppet version in Vagrant-puppet/install_puppet.sh (defaults to Puppet 3)
+4.	`vagrant up` and watch your new virtual machine get fully provisioned
+5.	`vagrant ssh` and have a look around
+6.	Now try making a change to some YAML data. Edit [`common.yaml`](hieradata/common.yaml) and add/remove a DNS server, just for fun
+7.	`vagrant provision`, now watch the DNS client configuration recieve your change.
 
-### Setting facter facts for Vagrant to use (i.e. `app_role` or `app_tier`)
-  
+### Setting facter facts for Vagrant to use (i.e. `app_role` or `app_tier`\)
+
 Use environment variables to set facter facts that get passed to Vagrant.
 
 ```
@@ -28,26 +32,30 @@ $ APP_ROLE=webserver vagrant provision
 or...
 $ APP_ROLE=webserver APP_TIER=production vagrant provision
 ```
-  
 
-## Compatibility
+Compatibility
+-------------
 
 Tested with Puppet v3.8 (open source) on CentOS 6.7 and Ubuntu Server 14.04 LTS.
 
-## Contributing
+Tested with Puppet v4.4.1 (open source) on Ubuntu Server 14.04 LTS
 
-1. Fork it!
-2. Create your feature branch: `git checkout -b my-new-feature`
-3. Commit your changes: `git commit -am 'Add some feature'`
-4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request :D
+Contributing
+------------
 
-## History
+1.	Fork it!
+2.	Create your feature branch: `git checkout -b my-new-feature`
+3.	Commit your changes: `git commit -am 'Add some feature'`
+4.	Push to the branch: `git push origin my-new-feature`
+5.	Submit a pull request :D
+
+History
+-------
 
 Nov 2015: Initial commit
 
-
-## Credits
+Credits
+-------
 
 [Sean S. King](https://github.com/seanscottking), author
 
@@ -55,7 +63,7 @@ Thanks to [Rob Nelson](http://rnelson0.com). His project [puppetinabox](https://
 
 Thanks to [Craig Dunn](www.craigdunn.org) and [Gary Larizza](http://garylarizza.com) for their broad research on ways to make Puppet not suck.
 
-
-## License
+License
+-------
 
 [See LICENSE.md](LICENSE.md)

--- a/Vagrant-puppet/install_puppet.sh
+++ b/Vagrant-puppet/install_puppet.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Select your puppet version to install (3 || 4)
+puppet_version=3
+
 e() {
   echo "$0: $@"
 }
@@ -22,34 +25,61 @@ if [ -f '/etc/redhat-release' ]; then
     yum install -y redhat-lsb-core
 
     case "$(lsb_release -sr | cut -d'.' -f1)" in
-  
+
         6)
           yum install -y http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
           yum install -y https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
           ;;
-          
+
         *)
           err "Unsupported Operating System Version"
           exit 1
           ;;
-  
+
     esac
   fi
-  
+
   yum install -y puppet
 
 elif [ -f '/etc/debian_version' ]; then
-  
-  if [ "$(dpkg -S puppetlabs-release 2>/dev/null)" ]; then
-    # Puppet repo already installed, exiting silently
-    exit 0
-  else
-    SHORT_CODENAME="$(lsb_release -c -s)"
-    wget -O /tmp/puppetlabs-release-"$SHORT_CODENAME".deb https://apt.puppetlabs.com/puppetlabs-release-"$SHORT_CODENAME".deb
-    dpkg -i /tmp/puppetlabs-release-"$SHORT_CODENAME".deb
-    apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confnew" install puppet
-  fi
+
+  case "$puppet_version" in
+
+    4) if [ ! puppet --version == 4* ]; then
+        echo "Puppet Agent 4.x.x is already installed. Moving on..."
+    else
+
+      # Add puppet repo and install puppet
+      wget https://apt.puppetlabs.com/puppetlabs-release-pc1-trusty.deb && \
+      sudo dpkg -i puppetlabs-release-pc1-trusty.deb && \
+      sudo apt-get update -yq && \
+      sudo apt-get -o Dpkg::Options::="--force-confold" install -yq puppet-agent
+
+      # Link puppet install to /usr/bin so it is in out PATH
+      sudo ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+
+      # Add puppet cron job to refresh every 30 mins
+      sudo puppet resource cron puppet-agent ensure=present user=root minute=30 \
+        command='/usr/bin/puppet agent --onetime --no-daemonize --splay'
+
+      # Ensure the puppet agent is running
+      sudo puppet resource service puppet ensure=running enable=true
+    fi;;
+
+  3) if [ ! puppet --version == 3* ]; then
+      echo "Puppet Agent 3.x.x is already installed. Moving on..."
+    else
+      SHORT_CODENAME="$(lsb_release -c -s)"
+      wget -O /tmp/puppetlabs-release-"$SHORT_CODENAME".deb https://apt.puppetlabs.com/puppetlabs-release-"$SHORT_CODENAME".deb
+      dpkg -i /tmp/puppetlabs-release-"$SHORT_CODENAME".deb
+      apt-get update
+      DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confnew" install puppet
+    fi;;
+
+  *) err "You must select either Puppet version 3 or 4"
+    exit 1;;
+
+  esac
 
 else
   err "Unsupported Operating System"


### PR DESCRIPTION
I have added a variable at the top of install_puppet.sh to allow the user the option to install puppet 3 or 4. This option only works for Ubuntu Server at this time. If you would like I can figure out what needs to be done to add support to CentOS. The default is set for puppet 3.
